### PR TITLE
msm8956: Build HIDL Manager for IMS

### DIFF
--- a/libhidl/Android.mk
+++ b/libhidl/Android.mk
@@ -14,8 +14,32 @@
 # limitations under the License.
 
 include $(CLEAR_VARS)
-LOCAL_SHARED_LIBRARIES := libhidltransport
+
+LOCAL_SRC_FILES := \
+
+LOCAL_SHARED_LIBRARIES := \
+    libhidltransport
+
+LOCAL_C_INCLUDES := \
+
 LOCAL_MODULE := android.hidl.base@1.0
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_CLASS := SHARED_LIBRARIES
+
+include $(BUILD_SHARED_LIBRARY)
+
+
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := \
+
+LOCAL_SHARED_LIBRARIES := \
+    libhidltransport
+
+LOCAL_C_INCLUDES := \
+
+LOCAL_MODULE := android.hidl.manager@1.0
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := SHARED_LIBRARIES
+
 include $(BUILD_SHARED_LIBRARY)

--- a/msm8956.mk
+++ b/msm8956.mk
@@ -163,6 +163,7 @@ PRODUCT_PACKAGES += \
     memtrack.msm8952 \
     libdisplayconfig \
     liboverlay \
+    libqdMetaData \
     libqdMetaData.system \
     libgenlock \
     vendor.display.config@1.0 \
@@ -226,7 +227,8 @@ PRODUCT_PACKAGES += \
 # HIDL
 PRODUCT_PACKAGES += \
     android.hidl.base@1.0 \
-    android.hidl.manager@1.0
+    android.hidl.manager@1.0 \
+    android.hidl.manager@1.0-java
 
 # IMS
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
*Extracted from here: https://github.com/LineageOS/android_device_leeco_msm8996-common/tree/lineage-15.1/libhidl
and also: https://github.com/LineageOS/android_device_leeco_msm8996-common/commit/6c154f7603c10ff58c59d8f0a75d13f96abb6f2f#diff-1328285a68b025dac24ed87d43a98c32

*Error log: 06-22 13:21:54.709 E/ims_camera_jni(3044): Error loading library lib-imscamera.so: dlopen failed: library "android.hidl.manager@1.0.so" not found

Signed-off-by: AmolAmrit <amol.amrit03@outlook.com>